### PR TITLE
Enclose TSTP infos into a list

### DIFF
--- a/src/prover/Proof.ml
+++ b/src/prover/Proof.ml
@@ -484,7 +484,7 @@ module S = struct
          let pp_infos out = function
            | [] -> ()
            | l ->
-             Format.fprintf out ",@ %a"
+             Format.fprintf out ",@ [%a]"
                (Util.pp_list ~sep:", " UntypedAST.pp_attr_tstp) l
          in
          let infos = p.step |> Step.infos in


### PR DESCRIPTION
According to Dolmen, this is required by the TPTP syntax