### PR TITLE
[DK parsing] fix mk_def

### DIFF
--- a/src/parsers/Ast_dk.ml
+++ b/src/parsers/Ast_dk.ml
@@ -53,6 +53,6 @@ let ty_prop = T.prop
 let mk_ty_decl ?loc id ty = A.decl ?loc id ty
 let mk_assert ?loc ~name t = A.assert_ ?loc ~attrs:[A.attr_name name] t
 let mk_goal ?loc ~name t = A.goal ?loc ~attrs:[A.attr_name name] t
-let mk_def ?loc id ty body = A.def ?loc [A.mk_def id ty [body]]
+let mk_def ?loc id ty body = A.def ?loc [A.mk_def id ty [T.eq (mk_const id ty) body]]
 let mk_rewrite ?loc t = A.rewrite ?loc t
 


### PR DESCRIPTION
mk_def requires a (set of) rewrite rule, not the body of the definition.