### PR TITLE
Enumerate argument positions from the right

### DIFF
--- a/src/arbitrary/arTerm.ml
+++ b/src/arbitrary/arTerm.ml
@@ -215,7 +215,7 @@ let pos t =
       | T.DB _ -> PB.to_pos pb
       | T.AppBuiltin (_, l)
       | T.App (_, l) ->
-        oneof (stop :: List.mapi (fun i t' -> recurse t' (PB.arg i pb)) l) st
+        oneof (stop :: List.mapi (fun i t' -> recurse t' (PB.arg (List.length l - 1 - i) pb)) l) st
       | T.Fun (_,bod) ->
         oneof [stop; recurse bod (PB.body pb)] st
   in

--- a/src/core/InnerTerm.ml
+++ b/src/core/InnerTerm.ml
@@ -571,9 +571,9 @@ module Pos = struct
     | Bind(_, _, t'), P.Body subpos -> at t' subpos
     | App (t, _), P.Head subpos -> at t subpos
     | App (_, l), P.Arg (n,subpos) when n < List.length l ->
-      at (List.nth l n) subpos
+      at (List.nth l (List.length l - 1- n)) subpos
     | AppBuiltin (_, l), P.Arg(n,subpos) when n < List.length l ->
-      at (List.nth l n) subpos
+      at (List.nth l (List.length l - 1 - n)) subpos
     | _ -> fail_ t pos
 
   let rec replace t pos ~by = match t.ty, view t, pos with
@@ -588,12 +588,14 @@ module Pos = struct
     | HasType ty, App (f, l), P.Head subpos ->
       app ~ty (replace f subpos ~by) l
     | HasType ty, App (f, l), P.Arg (n,subpos) when n < List.length l ->
-      let t' = replace (List.nth l n) subpos ~by in
-      let l' = CCList.set_at_idx n t' l in
+      let n' = List.length l - 1 - n in
+      let t' = replace (List.nth l n') subpos ~by in
+      let l' = CCList.set_at_idx n' t' l in
       app ~ty f l'
     | HasType ty, AppBuiltin (s,l), P.Arg (n,subpos) when n < List.length l ->
-      let t' = replace (List.nth l n) subpos ~by in
-      let l' = CCList.set_at_idx n t' l in
+      let n' = List.length l - 1 - n in
+      let t' = replace (List.nth l n') subpos ~by in
+      let l' = CCList.set_at_idx n' t' l in
       app_builtin ~ty s l'
     | _ -> fail_ t pos
 end

--- a/src/core/Term.ml
+++ b/src/core/Term.ml
@@ -412,11 +412,12 @@ let all_positions ?(vars=false) ?(ty_args=true) ?(pos=Position.stop) t f =
       if ty_args || not (Type.is_tType (ty t)) then (
         f (PW.make t (PB.to_pos pb));
       );
+      let invi i = List.length tl - 1 - i in
       List.iteri
         (fun i t' ->
            (* if [t'] is a type parameter and [not ty_args], ignore *)
            if ty_args || not (Type.is_tType (ty t'))
-           then aux (PB.arg i pb) t')
+           then aux (PB.arg (invi i) pb) t')
         tl
   in
   aux (PB.of_pos pos) t


### PR DESCRIPTION
bugfix for the the bug produced by the following example, caused by positions shifting when substituting applied variables:

val i : type.

val a : i.
val f : i -> i -> i.
val g : i -> i .

assert (forall X. X (g (X a)) = a).
assert f a a = a.
