### PR TITLE
Avoid nested apps in STerm

### DIFF
--- a/src/core/STerm.ml
+++ b/src/core/STerm.ml
@@ -137,8 +137,9 @@ let var ?loc s = mk_var ?loc (V s)
 let v_wild = mk_var Wildcard
 let builtin ?loc s = make_ ?loc (AppBuiltin (s,[]))
 let app_builtin ?loc s l = make_ ?loc (AppBuiltin(s,l))
-let app ?loc s l = match s.term, l with
+let rec app ?loc s l = match s.term, l with
   | _, [] -> s
+  | App (s1,l1), _ -> app ?loc s1 (l1@l)
   | AppBuiltin (s1,l1), _ -> app_builtin ?loc s1 (l1@l)
   | _, _::_ -> make_ ?loc (App(s,l))
 let const ?loc s = make_ ?loc (Const s)


### PR DESCRIPTION
@c-cube Please have a look if this is the right way to fix this.

This is a bug fix for TPTP problem DAT/DAT281^1.p. The bug occurs during type inference and is triggered by nested use of the @-application-operator.