### PR TITLE
bugfix in Type.apply for polymorphic type arguments

### DIFF
--- a/src/core/Type.ml
+++ b/src/core/Type.ml
@@ -245,6 +245,9 @@ let apply ty0 args0 =
     | T.Bind (Binder.ForallTy, _, ty'), arg :: args' ->
       let arg = T.DB.eval env arg in
       aux ty' args' (DBEnv.push env arg)
+    | T.DB _, _ ->
+      let ty = T.DB.eval env ty in
+      aux ty args env
     | _ ->
       err_applyf_
         "@[<2>Type.apply:@ expected quantified or function type,@ but got @[%a@]"

--- a/tests/testTerm.ml
+++ b/tests/testTerm.ml
@@ -75,12 +75,24 @@ let test_whnf2 () =
   assert_equal ~cmp:T.equal ~printer:T.to_string t1 t';
   ()
 
+let test_polymorphic_app () =
+  (* Π α. α *)
+  let polyty = Type.forall_fvars [HVar.make ~ty:Type.tType 0] (Type.var_of_int 0) in
+  let f_poly = Term.const ~ty:polyty (ID.make "f_poly") in
+  (* ty → ty *)
+  let funty = Type.([ty] ==> ty) in
+  (* apply term of type `Π α. α` to terms of type `ty → ty` and `ty`: *)
+  let result = Term.app f_poly [Term.of_ty funty; a] in
+  assert_equal ~cmp:Type.equal ~printer:Type.to_string (Term.ty result) ty;
+  ()
+
 let suite =
   "test_term" >:::
     [ "test_db_shift" >:: test_db_shift
     ; "test_db_unshift" >:: test_db_unshift
     ; "test_whnf1" >:: test_whnf1
     ; "test_whnf2" >:: test_whnf2
+    ; "test_polymorphic_app" >:: test_polymorphic_app
     ]
 
 (** Properties *)


### PR DESCRIPTION
Please have a look at this fix. I haven't fully understood how `T.DB.eval` works exactly, but this seems to work.