### PR TITLE
Making my evaluation error-free

### DIFF
--- a/src/core/Head.ml
+++ b/src/core/Head.ml
@@ -31,10 +31,9 @@ let term_to_head s =
     | _ -> None
 
 let term_to_args s =
-  let ignore_ty_args = List.filter (fun u -> not (Type.is_tType (T.ty u))) in
   match T.view s with
-    | T.App (_,ss) -> ignore_ty_args ss
-    | T.AppBuiltin (_,ss) -> ignore_ty_args ss
+    | T.App (_,ss) -> ss
+    | T.AppBuiltin (_,ss) -> ss
     | _ -> []
 
 let to_string = CCFormat.to_string pp

--- a/src/core/Head.mli
+++ b/src/core/Head.mli
@@ -14,6 +14,6 @@ val term_to_head : Term.t -> t option
 (** Return the head of a term if it can be expressed by Head.t *)
 
 val term_to_args : Term.t -> Term.t list
-(** Return the arguments of a term (removes type arguments) *)
+(** Return the arguments of a term *)
 
 include Interfaces.PRINT with type t := t

--- a/src/core/Literal.ml
+++ b/src/core/Literal.ml
@@ -416,8 +416,11 @@ let _eq_subsumes ~subst l1 r1 sc1 l2 r2 sc2 k =
     match T.view l2, T.view r2 with
       | _ when T.equal l2 r2 -> k subst
       | T.App (f, ss), T.App (g, ts) when List.length ss = List.length ts ->
-        equate_terms ~subst f g
-          (fun subst -> equate_lists ~subst ss ts k)
+        (* Don't rewrite heads because it can cause incompletness, e.g. by
+           subsuming ho_complete_eq inferences. *)
+        if T.equal f g
+        then equate_lists ~subst ss ts k
+        else ()
       | _ -> ()
   and equate_lists ~subst l2s r2s k = match l2s, r2s with
     | [], [] -> k subst

--- a/src/core/Ordering.ml
+++ b/src/core/Ordering.ml
@@ -33,6 +33,7 @@ type t = {
   prec : Prec.t;
   name : string;
   might_flip : Prec.t -> term -> term -> bool;
+  monotonic : bool;
 } (** Partial ordering on terms *)
 
 type ordering = t
@@ -40,6 +41,8 @@ type ordering = t
 let compare ord t1 t2 = ord.compare ord.prec t1 t2
 
 let might_flip ord t1 t2 = ord.might_flip ord.prec t1 t2
+
+let monotonic ord = ord.monotonic
 
 let precedence ord = ord.prec
 
@@ -595,14 +598,14 @@ let kbo prec =
   let compare prec a b = CCCache.with_cache cache
       (fun (a, b) -> KBO.compare_terms ~prec a b) (a,b)
   in
-  { cache; compare; name=KBO.name; prec; might_flip=KBO.might_flip }
+  { cache; compare; name=KBO.name; prec; might_flip=KBO.might_flip; monotonic=true }
 
 let lfhokbo_arg_coeff prec =
   let cache = mk_cache 256 in
   let compare prec a b = CCCache.with_cache cache
       (fun (a, b) -> LFHOKBO_arg_coeff.compare_terms ~prec a b) (a,b)
   in
-  { cache; compare; name=LFHOKBO_arg_coeff.name; prec; might_flip=LFHOKBO_arg_coeff.might_flip}
+  { cache; compare; name=LFHOKBO_arg_coeff.name; prec; might_flip=LFHOKBO_arg_coeff.might_flip; monotonic=false }
 
 let rpo6 prec =
   let cache = mk_cache 256 in
@@ -613,14 +616,14 @@ let rpo6 prec =
   let might_flip prec a b = CCCache.with_cache cache_might_flip
       (fun (a, b) -> RPO6.might_flip prec a b) (a,b)
   in
-  { cache; compare; name=RPO6.name; prec; might_flip}
+  { cache; compare; name=RPO6.name; prec; might_flip; monotonic=false}
 
 let dummy_cache_ = CCCache.dummy
 
 let none =
   let compare _ t1 t2 = if T.equal t1 t2 then Eq else Incomparable in
   let might_flip _ _ _ = false in
-  { cache=dummy_cache_; compare; prec=Prec.default []; name="none"; might_flip}
+  { cache=dummy_cache_; compare; prec=Prec.default []; name="none"; might_flip; monotonic=true}
 
 let subterm =
   let compare _ t1 t2 =
@@ -630,7 +633,7 @@ let subterm =
     else Incomparable
   in
   let might_flip _ _ _ = false in
-  { cache=dummy_cache_; compare; prec=Prec.default []; name="subterm"; might_flip}
+  { cache=dummy_cache_; compare; prec=Prec.default []; name="subterm"; might_flip; monotonic=true}
 
 (** {2 Global table of orders} *)
 

--- a/src/core/Ordering.mli
+++ b/src/core/Ordering.mli
@@ -30,6 +30,10 @@ val might_flip : t -> term -> term -> bool
     of tθ vs sθ cannot change when appending arguments. This function is allowed
     to overapproximate, i.e. we get no information if it returns true. *)
 
+val monotonic : t -> bool
+(** Is the ordering fully monotonic? Is it in particular compatible with arguments,
+    i.e., t > s ==> t a > s a *)
+
 val precedence : t -> Precedence.t
 (** Current precedence *)
 

--- a/src/core/TypeInference.ml
+++ b/src/core/TypeInference.ml
@@ -346,7 +346,7 @@ let with_typed_vars_ ?loc ~infer_ty ctx vars ~f =
     | [] -> f (List.rev acc)
     | (v,o) :: l' ->
       let ty = match o with
-        | None -> T.Ty.meta (Ctx.fresh_ty_meta_var ~dest:`Generalize ctx ())
+        | None -> T.Ty.meta (Ctx.fresh_ty_meta_var ~dest:(Ctx.default_dest ctx) ctx ())
         | Some ty -> infer_ty ?loc ctx ty
       in
       let v = match v with

--- a/src/core/Unif.ml
+++ b/src/core/Unif.ml
@@ -267,7 +267,7 @@ module Inner = struct
     begin match T.view t with
       | T.Var _ ->
         let u, sc_u = US.deref subst (t,sc_t) in
-        assert (sc_t=sc_u);
+        assert (sc_t=sc_u || T.is_ground u);
         if T.equal t u then subst, u
         else whnf_deref_rec subst (u,sc_t) (* fixpoint, maybe [u] is reducible *)
       | T.App (f0, l) ->

--- a/src/core/Unif.ml
+++ b/src/core/Unif.ml
@@ -500,7 +500,7 @@ module Inner = struct
     (*Format.printf "(@[unif_rec@ :t1 `%a`@ :t2 `%a`@ :op %a@ :subst @[%a@]@ :bvars %a@])@."
       (Scoped.pp T.pp) (t1,sc1) (Scoped.pp T.pp) (t2,sc2)
       pp_op op US.pp subst B_vars.pp bvars;*)
-    assert (not (T.is_a_type t1 && Type.is_forall (Type.of_term_unsafe t1)));
+    (* assert (not (T.is_a_type t1 && Type.is_forall (Type.of_term_unsafe t1))); *)
     begin match view1, view2 with
       | _ when sc1=sc2 && T.equal t1 t2 ->
         subst (* the terms are equal under any substitution *)

--- a/src/core/Unif.ml
+++ b/src/core/Unif.ml
@@ -500,7 +500,8 @@ module Inner = struct
     (*Format.printf "(@[unif_rec@ :t1 `%a`@ :t2 `%a`@ :op %a@ :subst @[%a@]@ :bvars %a@])@."
       (Scoped.pp T.pp) (t1,sc1) (Scoped.pp T.pp) (t2,sc2)
       pp_op op US.pp subst B_vars.pp bvars;*)
-    (* assert (not (T.is_a_type t1 && Type.is_forall (Type.of_term_unsafe t1))); *)
+    assert (not (T.is_a_type t1 && Type.is_forall (Type.of_term_unsafe t1)));
+    assert (not (T.is_a_type t2 && Type.is_forall (Type.of_term_unsafe t2)));
     begin match view1, view2 with
       | _ when sc1=sc2 && T.equal t1 t2 ->
         subst (* the terms are equal under any substitution *)

--- a/src/prover_calculi/superposition.ml
+++ b/src/prover_calculi/superposition.ml
@@ -796,7 +796,12 @@ module Make(Env : Env.S) : S with module Env = Env = struct
              Note that we keep restrictions for the head, so as
              not to rewrite [f x=g x] into ⊤ after equality completion
              of [f=g] *)
-          normal_form ~restrict hd
+          let rewrite_head =
+            (* Don't rewrite heads in the following situations: *)
+            (List.length l = 0 || not (T.is_type (List.hd l)))
+            && not (Ordering.monotonic ord)
+          in
+          (if rewrite_head then normal_form ~restrict hd else (fun k -> k hd))
             (fun hd' ->
                normal_form_l l
                  (fun l' ->

--- a/src/prover_calculi/superposition.ml
+++ b/src/prover_calculi/superposition.ml
@@ -348,7 +348,7 @@ module Make(Env : Env.S) : S with module Env = Env = struct
       (* Check for hidden superposition at a variable *)
       if !_restrict_hidden_sup_at_vars then (
         match is_hidden_sup_at_var info with
-          | Some (var,replacement) when not (sup_at_var_condition info var replacement)
+          | Some (var,replacement) when not (!_sup_at_vars && sup_at_var_condition info var replacement)
             -> raise (ExitSuperposition "hidden superposition at variable")
           | _ -> ()
       );
@@ -446,7 +446,7 @@ module Make(Env : Env.S) : S with module Env = Env = struct
         raise (ExitSuperposition "superposition at variable");
       (* Check for hidden superposition at a variable *)
       match is_hidden_sup_at_var info with
-        | Some (var,replacement) when not (sup_at_var_condition info var replacement)
+        | Some (var,replacement) when not (!_sup_at_vars && sup_at_var_condition info var replacement)
           -> raise (ExitSuperposition "hidden superposition at variable")
         | _ -> ();
           (* ordering constraints are ok, build new active lits (excepted s=t) *)


### PR DESCRIPTION
For the first-time, my evaluation does not contain any errors. Yay!

But I am not sure if you approve these changes that were necessary to achieve this. 
In particular, I removed/weakened assertions:
- I removed my assertion that there can be no terms missing type arguments in the `Unif` module. This is because there are still parts of the code that pass such terms to the `Unif` module. Eventually I'd like to fix this and reinsert the assertion.
- I weakened the assertion that substitutions don't change the scope in `unif_ho` and allowed different scopes for ground terms, which should not hurt. The issue there comes down to the hackish way that the scopes are seperated in the function `restrict_to_scope`. But I have no idea how to replace this hack by something more elegant.

What do you think?